### PR TITLE
Added Australian KFC ordering app

### DIFF
--- a/src/data/Plexus.csv
+++ b/src/data/Plexus.csv
@@ -111,6 +111,7 @@ Japanese Dictionary Takoboto,September,2020,4,No reported issues,X,X
 Kaloricke Tabulky,September,2020,X,X,4,No reported issues
 Kasa,June,2020,1,Unusable,X,X
 Keepass2Android,August,2020,4,No reported issues,4,No reported issues
+KFC - Order On The Go,September,2020,1,Won't find stores due to lack of map support,X,X
 Komoot ,March,2020,4,No reported issues,4,No reported issues
 Lastpass ,June,2020,1,Unusable,X,X
 Lbry,August,2020,X,X,4,No reported issues


### PR DESCRIPTION
I hope I did this correctly. This is for the Australian KFC ordering app. You won't be able to order as you can only order once you have found a store which can only be done through maps integration. Obviously, not being able to order defeats the entire point of the app.

If it's relevant at all, I'm using GrapheneOS.