### PR TITLE
Change app.element.io link to matrix.to

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -29,7 +29,7 @@ const Header = ({ siteTitle }) => (
             </div>
           </Link>
           <a
-            href="https://app.element.io/#/room/#plexus:matrix.org"
+            href="https://matrix.to/#/#plexus:matrix.org"
             className="text-gray-100 hover:text-gray-200"
             rel="noopener noreferrer"
             target="_blank"


### PR DESCRIPTION
matrix.to allows people to choose alternative clients, therefore it is a better match than a link to app.element.io.