### PR TITLE
Update microG with google maps issue

### DIFF
--- a/src/data/Plexus.csv
+++ b/src/data/Plexus.csv
@@ -157,7 +157,7 @@ Google Home,November,2020,1,"Unusable, unless signed in, which is impossible wit
 Google Keep Notes,June,2020,1,Unusable,X,X
 Google Keyboard (Gboard),May,2020,4,No reported issues,4,No reported issues
 Google Lens,November,2020,1,"Won't operate without Google app, which doesn't open without Google Play Services",X,X
-Google Maps,September,2020,3,Cannot add Google account,4,No reported issues
+Google Maps,September,2020,2,Cannot add Google account,0,Cannot open if logged in
 Google Messages,November,2020,4,No reported issues,X,X
 Google News,November,2020,1,"Unusable, app won't open",X,X
 Google Pay,November,2020,1,"Unusable",X,X
@@ -406,8 +406,8 @@ TTS Util,June,2020,4,No reported issues,4,No reported issues
 Tutanota,May,2020,4,No reported issues,4,No reported issues
 Twitter,November,2020,3,Notifications not working,3,No notifications
 Ubank,November,2020,3,No notifications and no Tap & Pay (detects root),X,X
-Uber,June,2020,1,Unusable,4,No reported issues
-Uber Eats,September,2020,3,"Google Play Services Warning, but no effect",4,No reported issues
+Uber,June,2020,1,Unusable,2,"Add Payment screen not working, map tiles not visible"
+Uber Eats,September,2020,3,"Google Play Services Warning, but no effect",3,"Add Payment screen not working, map tiles not visible"
 UPS,November,2020,X,X,4,No reported issues
 Up Banking,November,2020,1,Cannot log in,X,X
 v2rayNG,November,2020,4,No reported issues,X,X


### PR DESCRIPTION
I'm currently unable to open Google Maps on the latest version if I'm logged in. It will open and immediately go into a force-close loop until I force kill the app. Running MicroG via CalyxOS on the latest version for the Pixel 4a. Mapping tiles are not showing in the Uber apps as well (which I'm guessing depend on Google Maps working). I didn't get a chance to try Lyft.